### PR TITLE
Relationship is not protected correctly:

### DIFF
--- a/lib/protector/adapters/active_record.rb
+++ b/lib/protector/adapters/active_record.rb
@@ -19,7 +19,7 @@ module Protector
         ::ActiveRecord::Base.send :include, Protector::Adapters::ActiveRecord::Validations
         ::ActiveRecord::Relation.send :include, Protector::Adapters::ActiveRecord::Relation
         ::ActiveRecord::Associations::SingularAssociation.send :include, Protector::Adapters::ActiveRecord::Association
-        ::ActiveRecord::Associations::SingularAssociation.send :include, Protector::Adapters::ActiveRecord::SingularAssociation
+        # ::ActiveRecord::Associations::SingularAssociation.send :include, Protector::Adapters::ActiveRecord::SingularAssociation
         ::ActiveRecord::Associations::CollectionAssociation.send :include, Protector::Adapters::ActiveRecord::Association
         ::ActiveRecord::Associations::Preloader.send :include, Protector::Adapters::ActiveRecord::Preloader
         ::ActiveRecord::Associations::Preloader::Association.send :include, Protector::Adapters::ActiveRecord::Preloader::Association

--- a/lib/protector/adapters/active_record/association.rb
+++ b/lib/protector/adapters/active_record/association.rb
@@ -16,6 +16,7 @@ module Protector
             alias_method 'scoped', 'scope_with_protector'
           end
 
+          alias_method_chain :reader, :protector
           alias_method_chain :build_record, :protector
         end
 
@@ -30,6 +31,13 @@ module Protector
         def build_record_with_protector(*args)
           return build_record_without_protector(*args) unless protector_subject?
           build_record_without_protector(*args).restrict!(protector_subject)
+        end
+
+        # Reader has to be explicitly overrided for cases when the
+        # loaded association is cached
+        def reader_with_protector(*args)
+          return reader_without_protector(*args) unless protector_subject?
+          reader_without_protector(*args).try :restrict!, protector_subject
         end
 
         # AR 4.2 hack - Disable skip_statement_cache?


### PR DESCRIPTION
- singular association: when there is no default scoping, Protector is bypassed
  (see https://github.com/rails/rails/blob/v5.0.2/activerecord/lib/active_record/associations/singular_association.rb#L54)

- has many association: there is no reader patch for AssociationCollectionProxy
  (see https://github.com/rails/rails/blob/v5.0.2/activerecord/lib/active_record/associations/collection_association.rb#L29)

- calling `restrict!(protect_subject)` on AssociationCollectionProxy does nothing...

**TIP** `dsl.rb#279` breakpoint to make sure a model being protected